### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Gradle Build
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: ['*']


### PR DESCRIPTION
Potential fix for [https://github.com/rahulsom/muval/security/code-scanning/2](https://github.com/rahulsom/muval/security/code-scanning/2)

The recommended fix is to add a `permissions` block to `.github/workflows/build.yml`. Since the workflow's sole job is to invoke a reusable Gradle build workflow, it's best to provide minimal permissions required for that build. Unless the job pushes code, creates releases, or manages pull requests, you should start with only read access to contents. This can be achieved by adding:

```yaml
permissions:
  contents: read
```
at the top level (right after the `name` and before or after `on:`). If the reusable workflow requires more (e.g., to publish artifacts or handle releases), you would need to add additional specific permissions (such as `packages: write`, `pull-requests: write`). For now, the minimal recommended block is `contents: read`, as suggested by CodeQL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
